### PR TITLE
look explicitly for children of monitor folder prefixed with `lock-` …

### DIFF
--- a/src/zookeeperLock.ts
+++ b/src/zookeeperLock.ts
@@ -237,7 +237,7 @@ export class ZookeeperLock {
                             }
                             if (locks) {
                                 var filtered = locks.filter((l) => {
-                                    return l !== null && l.indexOf('-') > -1;
+                                    return l !== null && l.indexOf('lock-') === 0;
                                 });
 
                                 debuglog(JSON.stringify(filtered));


### PR DESCRIPTION
…to reduce chance of bad parse
