### PR TITLE
first stab at consolidated lock state variable…

### DIFF
--- a/src/zookeeperLock.ts
+++ b/src/zookeeperLock.ts
@@ -34,14 +34,55 @@ export class ZookeeperLockAlreadyLockedError extends Error {
     }
 }
 
-export class Configuration {
+export class ZookeeperLockConfiguration {
+    /**
+     * locators (https://github.com/metamx/locators) compatible zookeeper server locator
+     */
     serverLocator? : Locator;
+    /**
+     * prefix which will be placed in front of all locks created from this lock
+     */
     pathPrefix? : string;
+    /**
+     * zookeeper client session timeout
+     */
     sessionTimeout? : number;
+    /**
+     * dual function parameter, functioning both as zookeeper lock 'reconnect' delay
+     * as well as internal zookeeper client spinDelay
+     */
     spinDelay? : number;
+    /**
+     * dual function parameter, functioning both as zookeeper lock 'reconnect' limit
+     * as well as internal zookeeper client retries
+     */
     retries? : number;
+    /**
+     * when true, all calls to unlock will destroy the lock, detaching all event listeners, in addition
+     * to the normal disconnect. defaults to true to reduce the chance of leaky usage
+     */
+    autoDestroyOnUnlock? : boolean;
+    /**
+     * when true, if the lock is not obtainable immediately, fail with a ZookeeperLockAlreadyLockedError
+     */
     failImmediate? : boolean;
+    /**
+     * allowed number of maximum concurrent holders of a lock, defaults to 1 for traditional lock-like
+     * behavior. Note that this value is NOT enforced, it's merely an agreement that all lock clients
+     * agree to follow when working with this lock path, but allows using the zookeeper lock for additional
+     * cluster orchestration roles like controlling the maximum number of concurrent workers
+     */
     maxConcurrentHolders? : number;
+    /**
+     * if set to true, set a timeout defaulting to 10 seconds to give status updates on the lock while it
+     * is connected to zookeeper, used to help debug working with the locks to detect leaks or what not
+     */
+    enableTraceLog? : boolean;
+
+    /**
+     * the rate at which debug trace logs are emitted when enableTraceLog is set to true
+     */
+    traceLogRefresh? : number;
 }
 
 
@@ -49,27 +90,39 @@ export class ZookeeperLock extends EventEmitter {
     path : string;
     key : string;
 
-    private config : Configuration = null;
+    private config : ZookeeperLockConfiguration = null;
     public client : zk.Client = null;
-    private timedOut : boolean = false;
-    private locked : boolean = false;
-    private retryCount : number = 0;
-    private destroyed : boolean = false;
+    public state : string = ZookeeperLock.States.UNLOCKED;
 
+    private retryCount : number = 0;
     private timeout : number;
 
-    private static config : Configuration = null;
+    private created : Date;
+
+    private static config : ZookeeperLockConfiguration = null;
 
     public static Signals = {
         LOST: 'lost',
         TIMEOUT: 'timeout'
     };
 
+    public static States = {
+        UNLOCKED: 'UNLOCKED',
+        LOCKING: 'LOCKING',
+        LOCKED: 'LOCKED',
+        UNLOCKING: 'UNLOCKING',
+        ERROR: 'ERROR',
+        LOST: 'LOST',
+        TIMEOUT: 'TIMEOUT',
+        ALREADY_LOCKED: 'ALREADY_LOCKED',
+        DESTROYED: 'DESTROYED'
+    };
+
     /**
      * create a new zk lock
      * @param config
      */
-    constructor(config : Configuration) {
+    constructor(config : ZookeeperLockConfiguration) {
         super();
         this.config = config ? config : {};
         if (this.config.sessionTimeout == null) {
@@ -84,10 +137,66 @@ export class ZookeeperLock extends EventEmitter {
         if (this.config.maxConcurrentHolders == null) {
             this.config.maxConcurrentHolders = 1;
         }
+        this.config.autoDestroyOnUnlock = this.config.autoDestroyOnUnlock != null ? this.config.autoDestroyOnUnlock : true;
+
+        if (this.config.enableTraceLog) {
+            if (!this.config.traceLogRefresh) {
+                this.config.traceLogRefresh = 10000;
+            }
+        }
 
         debuglog(JSON.stringify(this.config));
     }
 
+    private changeState(newState : string) {
+
+        const logIgnored = () => {
+            debuglog(`--${this.path && this.key ? `${this.path}/${this.key}` : this.path ? this.path : 'unknown connection'}: ignored state transition ${this.state} -> ${newState}`);
+        };
+        switch (this.state) {
+            case ZookeeperLock.States.DESTROYED:
+            case ZookeeperLock.States.LOST:
+                logIgnored();
+                return;
+            case ZookeeperLock.States.ALREADY_LOCKED:
+            case ZookeeperLock.States.TIMEOUT:
+            case ZookeeperLock.States.ERROR:
+                if (newState !== ZookeeperLock.States.DESTROYED &&
+                    newState !== ZookeeperLock.States.LOST) {
+                    logIgnored();
+                    return;
+                }
+                break;
+            case ZookeeperLock.States.UNLOCKED:
+                if (newState !== ZookeeperLock.States.LOCKING &&
+                    newState !== ZookeeperLock.States.ERROR &&
+                    newState !== ZookeeperLock.States.LOST &&
+                    newState !== ZookeeperLock.States.DESTROYED) {
+                    logIgnored();
+                    return;
+                }
+                break;
+            case ZookeeperLock.States.LOCKING:
+                if (newState !== ZookeeperLock.States.LOCKED &&
+                    newState !== ZookeeperLock.States.ERROR &&
+                    newState !== ZookeeperLock.States.ALREADY_LOCKED &&
+                    newState !== ZookeeperLock.States.TIMEOUT &&
+                    newState !== ZookeeperLock.States.LOST) {
+                    logIgnored();
+                    return;
+                }
+                break;
+            case ZookeeperLock.States.LOCKED:
+                if (newState !== ZookeeperLock.States.UNLOCKING &&
+                    newState !== ZookeeperLock.States.LOST) {
+                    logIgnored();
+                    return;
+                }
+        }
+
+        debuglog(`${this.path && this.key ? `${this.path}/${this.key}` : this.path ? this.path : 'unknown connection'}: state transition ${this.state} -> ${newState}`);
+        this.state = newState;
+    }
 
     /**
      * create a zookeeper client which powers the lock, done when creating a new lock
@@ -95,6 +204,9 @@ export class ZookeeperLock extends EventEmitter {
      * @returns {Promise<any>}
      */
     private createClient() : Promise<any>|any {
+        if (this.state === ZookeeperLock.States.DESTROYED) {
+            return Promise.reject(new Error('cannot create client, lock destroyed'));
+        }
         debuglog('creating client');
         if (this.client != null) {
             debuglog('client already created');
@@ -128,6 +240,7 @@ export class ZookeeperLock extends EventEmitter {
                         this.removeAllListeners();
                         this.client.close();
                         this.client = null;
+                        this.changeState(ZookeeperLock.States.LOST);
                     }
                 });
 
@@ -145,8 +258,8 @@ export class ZookeeperLock extends EventEmitter {
      * @returns {Promise<any>}
      */
     public connect = (delay : number = 0) : Promise<any> => {
-        if (this.destroyed) {
-            return Promise.reject('cannot connect, lock destroyed');
+        if (this.state === ZookeeperLock.States.DESTROYED) {
+            return Promise.reject(new Error('cannot create client, lock destroyed'));
         }
         debuglog('connecting...');
         return Promise.delay(delay).then(() => {
@@ -166,15 +279,45 @@ export class ZookeeperLock extends EventEmitter {
         });
     };
 
+    private traceLog = () => {
+        setTimeout(() => {
+            const lifetime = Date.now() - this.created.getTime();
+            if (this.client) {
+                if (lifetime > 30000 && ((<any>this.client.getState()).name === 'SYNC_CONNECTED' || (<any>this.client.getState()).name === 'CONNECTED')) {
+                    if (this.state === ZookeeperLock.States.LOCKED) {
+                        debuglog('----------------------------');
+                        debuglog(`long held lock (${lifetime / 1000} sec) detected ${this.path && this.key ? `${this.path}/${this.key}` : this.path ? this.path : 'unknown connection'}`);
+                        debuglog('----------------------------');
+                    } else {
+                        debuglog('++++++++++++++++++++++++++++');
+                        debuglog('++++++++++++++++++++++++++++');
+                        debuglog(`potential leak detected, connection is open, but in state ${this.state} for ${lifetime / 1000} sec on ${this.path && this.key ? `${this.path}/${this.key}` : this.path ? this.path : 'unknown connection'}`);
+                        debuglog('++++++++++++++++++++++++++++');
+                        debuglog('++++++++++++++++++++++++++++');
+                    }
+                } else {
+                    debuglog(`${this.path && this.key ? `${this.path}/${this.key}` : this.path ? this.path : 'unknown connection'} alive and ${this.state} for ${lifetime} is ${(<any>this.client.getState()).name}`);
+                }
+                this.traceLog();
+            }
+        }, this.config.traceLogRefresh);
+    };
+
     private connectHelper = () : Promise<any> => {
         return new Promise<any>((resolve, reject) => {
             this.client.once('connected', () => {
                 debuglog('connected');
-                if (this.destroyed) {
+                if (this.state === ZookeeperLock.States.DESTROYED) {
                     this.disconnect().finally(() => {
                         reject('lock destroyed while connecting');
                     });
                 } else {
+                    if (!this.created) {
+                        this.created = new Date();
+                    }
+                    if (this.config.enableTraceLog) {
+                        this.traceLog();
+                    }
                     resolve(true);
                 }
             });
@@ -203,6 +346,7 @@ export class ZookeeperLock extends EventEmitter {
                 .timeout(timeout, `failed to disconnect within ${timeout / 1000} seconds, returning anyway`)
                 .catch(Promise.TimeoutError, (e) => {
                     debuglog(e && e.message ? e.message : e);
+                    this.changeState(ZookeeperLock.States.DESTROYED);
                     if (this.client) {
                         this.client.removeAllListeners();
                     }
@@ -223,6 +367,7 @@ export class ZookeeperLock extends EventEmitter {
                 } else {
                     debuglog('disconnected');
                 }
+                this.changeState(ZookeeperLock.States.UNLOCKED);
                 resolve(true);
 
             });
@@ -236,13 +381,13 @@ export class ZookeeperLock extends EventEmitter {
      * @returns {Promise<any>}
      */
     public destroy = () : Promise<boolean> => {
-        this.destroyed = true;
         return this.disconnect().then(() => {
             if (this.key && this.path) {
                 debuglog(`${this.path}/${this.key}: destroyed`);
             } else {
                 debuglog(`destroyed`);
             }
+            this.changeState(ZookeeperLock.States.DESTROYED);
             this.removeAllListeners();
             // wait for session timeout for ephemeral lock to go away
             // return Promise.delay(this.config.sessionTimeout).thenReturn(true);
@@ -257,7 +402,7 @@ export class ZookeeperLock extends EventEmitter {
      */
     private reconnect = () : Promise<any> => {
         this.retryCount++;
-        if (this.destroyed || this.config.failImmediate || (this.retryCount <= this.config.retries) || !this.locked) {
+        if (this.state === ZookeeperLock.States.DESTROYED || this.config.failImmediate || (this.retryCount <= this.config.retries) || this.state !== ZookeeperLock.States.LOCKED) {
             return Promise.resolve(false);
         }
         debuglog(`reconnecting ${this.retryCount}...`);
@@ -274,6 +419,8 @@ export class ZookeeperLock extends EventEmitter {
      * @returns {Promise<any>}
      */
     public unlock = (destroy : boolean = true) : Promise<any> => {
+        destroy = destroy && this.config.autoDestroyOnUnlock;
+        this.changeState(ZookeeperLock.States.UNLOCKING);
         return new Promise<any>((resolve, reject) => {
             const cleanup = () => {
                 let destroyFunc : () => Promise<any>;
@@ -299,7 +446,7 @@ export class ZookeeperLock extends EventEmitter {
 
             if (this.client) {
                 if (this.path && this.key) {
-                    debuglog(`${this.path}/${this.key}: unlocking..,`);
+                    debuglog(`${this.path}/${this.key}: unlocking...`);
                     this.client.remove(
                         `${this.path}/${this.key}`,
                         (err) => {
@@ -315,6 +462,7 @@ export class ZookeeperLock extends EventEmitter {
                 }
             } else {
                 debuglog(`client not connected, skipping unlock and cleanup`);
+                this.changeState(ZookeeperLock.States.UNLOCKED);
                 resolve(true);
             }
         });
@@ -336,7 +484,7 @@ export class ZookeeperLock extends EventEmitter {
             ` with ${this.config.maxConcurrentHolders} concurrent lock holders` :
             '';
 
-        if (this.locked) {
+        if (this.state === ZookeeperLock.States.LOCKED) {
             debuglog('already locked');
             return Promise.resolve(this);
         }
@@ -349,7 +497,7 @@ export class ZookeeperLock extends EventEmitter {
             return this.lockHelper(path, nodePath, timeout)
                 .timeout(timeout, 'timeout')
                 .catch(Promise.TimeoutError, (te) => {
-                    this.timedOut = true;
+                    this.changeState(ZookeeperLock.States.TIMEOUT);
                     this.disconnect();
                     throw new ZookeeperLockTimeoutError('timeout', path, timeout);
                 });
@@ -362,7 +510,7 @@ export class ZookeeperLock extends EventEmitter {
     private lockHelper = (path : string, nodePath : string, timeout? : number) : Promise<any> => {
         return this.connect()
             .then(() => {
-                this.timedOut = false;
+                this.changeState(ZookeeperLock.States.LOCKING);
                 debuglog(`making lock at ${nodePath}`);
                 return this.makeLockDir(nodePath);
             })
@@ -374,11 +522,10 @@ export class ZookeeperLock extends EventEmitter {
                 return this.waitForLock(nodePath);
             })
             .then(() => {
-                this.locked = true;
+                this.changeState(ZookeeperLock.States.LOCKED);
                 debuglog(`${this.path}/${this.key}: lock acquired`);
                 return this;
             }).catch((err) => {
-                this.locked = false;
                 debuglog(`${this.path}/${this.key}: error grabbing lock: ${err.message}`);
                 throw err;
             });
@@ -395,14 +542,15 @@ export class ZookeeperLock extends EventEmitter {
             this.client.mkdirp(
                 path,
                 (err) => {
-                    if (this.checkBail()) {
+                    if (this.continueLocking()) {
+
+                        if (err) {
+                            return reject(new Error(`Failed to create directory: ${path} due to: ${err}.`));
+                        }
+                        resolve(true);
+                    } else if (this.shouldRejectPromise()) {
                         return reject(new Error('aborting lock process'));
                     }
-
-                    if (err) {
-                        return reject(new Error(`Failed to create directory: ${path} due to: ${err}.`));
-                    }
-                    resolve(true);
                 }
             );
         });
@@ -422,19 +570,19 @@ export class ZookeeperLock extends EventEmitter {
                 new Buffer('lock'),
                 zk.CreateMode.EPHEMERAL_SEQUENTIAL,
                 (err, lockPath) => {
-                    if (this.checkBail()) {
+                    if (this.continueLocking()) {
+                        if (err) {
+                            return reject(new Error(`Failed to create node: ${lockPath} due to: ${err}.`));
+                        }
+                        debuglog(`init lock: ${path}, ${lockPath.replace(path + '/', '')}`);
+
+                        this.path = path;
+                        this.key = lockPath.replace(path + '/', '');
+
+                        resolve(true);
+                    } else if (this.shouldRejectPromise()) {
                         return reject(new Error('aborting lock process'));
                     }
-
-                    if (err) {
-                        return reject(new Error(`Failed to create node: ${lockPath} due to: ${err}.`));
-                    }
-                    debuglog(`init lock: ${path}, ${lockPath.replace(path + '/', '')}`);
-
-                    this.path = path;
-                    this.key = lockPath.replace(path + '/', '');
-
-                    resolve(true);
                 }
             );
         });
@@ -452,8 +600,28 @@ export class ZookeeperLock extends EventEmitter {
     };
 
 
-    private checkBail = () => {
-        return this.timedOut || this.destroyed || (this.client && (<any>this.client.getState()).name !== 'SYNC_CONNECTED');
+    /**
+     * are we on the happy path to continue locking?
+     * @returns {boolean|zk.Client}
+     */
+    private continueLocking = () => {
+        return this.state === ZookeeperLock.States.LOCKING && (this.client && (<any>this.client.getState()).name === 'SYNC_CONNECTED');
+    };
+
+    /**
+     * check for states that result from triggers that resolve the external promise chain of the locking process.
+     * The zookeeper client fires all event handlers when it is disconnected, so events like timeouts, already
+     * locked errors, and even unlocking can cause unintended stray events, so we should just bail from these
+     * handlers rather than trigger unintended rejections from race conditions with the intended external rejections
+     * @returns {boolean}
+     */
+    private shouldRejectPromise = () => {
+        //
+        const shouldReject = this.state !== ZookeeperLock.States.TIMEOUT && this.state !== ZookeeperLock.States.ALREADY_LOCKED && this.state !== ZookeeperLock.States.UNLOCKING;
+        if (shouldReject) {
+            debuglog(`${this.path && this.key ? `${this.path}/${this.key}` : this.path ? this.path : 'unknown connection'}: aborting lock process from state ${this.state}`);
+        }
+        return shouldReject;
     };
     /**
      * helper method that does the grunt of the work of waiting for the lock. This method does 2 things, first
@@ -467,66 +635,67 @@ export class ZookeeperLock extends EventEmitter {
      */
     private waitForLockHelper = (resolve, reject, path) : void => {
         debuglog(`${path} wait loop.`);
-        if (this.locked || this.checkBail()) {
+        if (this.continueLocking()) {
+            this.client.getChildren(
+                path,
+                (event) => {
+                    if (this.continueLocking()) {
+                        debuglog(`${path}/${this.key}: children changed.`);
+                        this.waitForLockHelper(resolve, reject, path);
+                    } else if (this.shouldRejectPromise()) {
+                        return reject(new Error('aborting lock process'));
+                    }
+                },
+                (err, locks, state) => {
+                    if (this.continueLocking()) {
+                        try {
+                            if (err || !locks || locks.length === 0) {
+                                const errMsg = err && err.message ? err.message : 'no children';
+                                debuglog(`${path}/${this.key}: failed to get children: ${errMsg}`);
+                                return reject(new Error(`Failed to get children node: ${errMsg}.`));
+                            }
+
+                            const sequence = this.filterLocks(locks)
+                                .map((l) => {
+                                    return ZookeeperLock.getSequenceNumber(l);
+                                })
+                                .filter((l) => {
+                                    return l >= 0;
+                                });
+
+                            debuglog(`${path}/${this.key}: lock sequence: ${JSON.stringify(sequence)}`);
+
+                            const mySeq = ZookeeperLock.getSequenceNumber(this.key);
+
+                            const sorted : Array<number> = sequence.sort((a, b) => {
+                                return a - b;
+                            });
+                            const offset = Math.min(sorted.length, this.config.maxConcurrentHolders);
+                            const min = sorted[offset - 1];
+
+                            debuglog(`${path}/${this.key}: checking ${mySeq} less than ${min} + ${this.config.maxConcurrentHolders}`);
+                            if (mySeq <= min) {
+                                debuglog(`${path}/${this.key}: ${mySeq} can grab the lock on ${path}`);
+                                return resolve(true);
+                            } else if (this.config.failImmediate) {
+                                this.changeState(ZookeeperLock.States.ALREADY_LOCKED);
+                                debuglog(`${path}/${this.key}: failing immediately`);
+                                this.unlock().finally(() => {
+                                    return reject(new ZookeeperLockAlreadyLockedError('already locked', path));
+                                });
+                            }
+                            debuglog(`${path}/${this.key}: lock not available for ${mySeq} on ${path}, waiting...`);
+                        } catch (ex) {
+                            debuglog(`${path}/${this.key}: error - ${ex.message}`);
+                            reject(ex);
+                        }
+                    } else if (this.shouldRejectPromise()) {
+                        return reject(new Error('aborting lock process'));
+                    }
+                });
+        } else if (this.shouldRejectPromise()) {
             return reject(new Error('aborting lock process'));
         }
-
-        this.client.getChildren(
-            path,
-            (event) => {
-                if (this.locked || this.checkBail()) {
-                    return reject(new Error('aborting lock process'));
-                }
-                debuglog(`${path}/${this.key}: children changed.`);
-                this.waitForLockHelper(resolve, reject, path);
-            },
-            (err, locks, state) => {
-                if (this.locked || this.checkBail()) {
-                    return reject(new Error('aborting lock process'));
-                }
-                try {
-                    if (err || !locks || locks.length === 0) {
-                        const errMsg = err && err.message ? err.message : 'no children';
-                        debuglog(`${path}/${this.key}: failed to get children: ${errMsg}`);
-                        return reject(new Error(`Failed to get children node: ${errMsg}.`));
-                    }
-
-                    const sequence = this.filterLocks(locks)
-                        .map((l) => {
-                            return ZookeeperLock.getSequenceNumber(l);
-                        })
-                        .filter((l) => {
-                            return l >= 0;
-                        });
-
-                    debuglog(`${path}/${this.key}: lock sequence: ${JSON.stringify(sequence)}`);
-
-                    const mySeq = ZookeeperLock.getSequenceNumber(this.key);
-
-                    // todo: fix me for max concurrent holders...
-                    // make sure we are first...
-                    const min = sequence.reduce((acc, elem) => {
-                        return Math.min(acc, elem);
-                    }, mySeq);
-
-                    debuglog(`${path}/${this.key}: checking ${mySeq} less than ${min} + ${this.config.maxConcurrentHolders}`);
-                    if (mySeq < (min + this.config.maxConcurrentHolders)) {
-                        debuglog(`${path}/${this.key}: ${mySeq} can grab the lock on ${path}`);
-                        return resolve(true);
-                    } else if (this.config.failImmediate) {
-                        this.locked = false;
-                        this.destroyed = true;
-                        debuglog(`${path}/${this.key}: failing immediately`);
-                        return reject(new ZookeeperLockAlreadyLockedError('already locked', path));
-                    }
-                    this.locked = false;
-                    debuglog(`${path}/${this.key}: lock not available for ${mySeq} on ${path}, waiting...`);
-                } catch (ex) {
-                    debuglog(`${path}/${this.key}: error - ${ex.message}`);
-                    reject(ex);
-                }
-            }
-        );
     };
 
     /**


### PR DESCRIPTION
…to better control interactions between promise lock actions and events from zookeeper client it sits on top of, definitely a bit disconnected since the enforcement is still spread about, but elimites a handful of disjoint variables. also added optional trace logging to troubleshoot locking issues