### PR TITLE
more chill locking

### DIFF
--- a/src/zookeeperLock.ts
+++ b/src/zookeeperLock.ts
@@ -358,7 +358,7 @@ export class ZookeeperLock extends EventEmitter {
      * @returns {Promise<any>}
      */
     public lock = (key : string, timeout : number = 0) : Promise<any> => {
-        const path = `/locks/${this.config.pathPrefix ? this.config.pathPrefix + '/' : '' }`;
+        const path = `/locks/${this.config.pathPrefix ? `${this.config.pathPrefix}/` : '' }`;
         const nodePath = `${path}${key}`;
         const someRandomExtraLogText = this.config.maxConcurrentHolders > 1 ?
             ` with ${this.config.maxConcurrentHolders} concurrent lock holders` :
@@ -482,7 +482,7 @@ export class ZookeeperLock extends EventEmitter {
             return this.config.serverLocator().then((location) => {
                 let server = location.host;
                 if (location.port) {
-                    server += ":" + location.port;
+                    server += `:${location.port}`;
                 }
                 debuglog('server location resolved');
                 debuglog(server);
@@ -682,10 +682,10 @@ export class ZookeeperLock extends EventEmitter {
                         if (err) {
                             return reject(new Error(`Failed to create node: ${lockPath} due to: ${err}.`));
                         }
-                        debuglog(`init lock: ${path}, ${lockPath.replace(path + '/', '')}`);
+                        debuglog(`init lock: ${path}, ${lockPath.replace(`${path}/`, '')}`);
 
                         this.path = path;
-                        this.key = lockPath.replace(path + '/', '');
+                        this.key = lockPath.replace(`${path}/`, '');
 
                         resolve(true);
                     } else if (this.shouldRejectPromise()) {
@@ -810,7 +810,7 @@ export class ZookeeperLock extends EventEmitter {
                                 }
                             };
 
-                            debuglog('watching for key ' + `${path}/${sorted[waitForIndex].key}`);
+                            debuglog(`watching for key ${path}/${sorted[waitForIndex].key}`);
                             (this.client as any).exists(
                                 `${path}/${sorted[waitForIndex].key}`,
                                 (event) => {
@@ -854,7 +854,7 @@ export class ZookeeperLock extends EventEmitter {
 
     private checkedLockedHelper = (key : string) => {
         return new Promise<boolean>((resolve, reject) => {
-            const path = `/locks/${this.config.pathPrefix ? this.config.pathPrefix + '/' : '' }`;
+            const path = `/locks/${this.config.pathPrefix ? `${this.config.pathPrefix}/` : '' }`;
             const nodePath = `${path}${key}`;
             this.client.getChildren(
                 nodePath,

--- a/src/zookeeperLock.ts
+++ b/src/zookeeperLock.ts
@@ -659,7 +659,7 @@ export class ZookeeperLock extends EventEmitter {
                         }
                     );
                 }
-            })
+            });
 
         });
     }


### PR DESCRIPTION
changes:
* check existence of directory before calling `mkdirp` of node-zookeeper-client, [which just calls create and catches exceptions blindly to ensure a path is created](https://github.com/alexguan/node-zookeeper-client/blob/master/index.js#L877) leading to many exceptions in zk logs in the form of 
```2017-04-25 20:06:58,632 [myid:14] - INFO  [ProcessThread(sid:14 cport:-1)::PrepRequestProcessor@645] - Got user-level KeeperException when processing sessionid:0xea5ba082c855af7a type:create cxid:0x0 zxid:0x19c01a398a4 txntype:-1 reqpath:n/a Error Path:/locks Error:KeeperErrorCode = NodeExists for /locks
2017-04-25 20:06:58,636 [myid:14] - INFO  [ProcessThread(sid:14 cport:-1)::PrepRequestProcessor@645] - Got user-level KeeperException when processing sessionid:0xea5ba082c855af7a type:create cxid:0x1 zxid:0x19c01a398a5 txntype:-1 reqpath:n/a Error Path:/locks/scheduled-report Error:KeeperErrorCode = NodeExists for /locks/scheduled-report
2017-04-25 20:06:58,640 [myid:14] - INFO  [ProcessThread(sid:14 cport:-1)::PrepRequestProcessor@645] - Got user-level KeeperException when processing sessionid:0xea5ba082c855af7a type:create cxid:0x2 zxid:0x19c01a398a6 txntype:-1 reqpath:n/a Error Path:/locks/scheduled-report/prod Error:KeeperErrorCode = NodeExists for /locks/scheduled-report/prod
2017-04-25 20:06:58,643 [myid:14] - INFO  [ProcessThread(sid:14 cport:-1)::PrepRequestProcessor@645] - Got user-level KeeperException when processing sessionid:0xea5ba082c855af7a type:create cxid:0x3 zxid:0x19c01a398a7 txntype:-1 reqpath:n/a Error Path:/locks/scheduled-report/prod/schedule Error:KeeperErrorCode = NodeExists for /locks/scheduled-report/prod/schedule
2017-04-25 20:06:58,647 [myid:14] - INFO  [ProcessThread(sid:14 cport:-1)::PrepRequestProcessor@645] - Got user-level KeeperException when processing sessionid:0xea5ba082c855af7a type:create cxid:0x4 zxid:0x19c01a398a8 txntype:-1 reqpath:n/a Error Path:/locks/scheduled-report/prod/schedule/schedule-959 Error:KeeperErrorCode = NodeExists for /locks/scheduled-report/prod/schedule/schedule-959
```
* [update to match latest iteration of locking recipe](https://zookeeper.apache.org/doc/r3.2.1/recipes.html#sc_recipes_Locks), setting an `exists` watcher on the key of the lock immediately preceeding this lock in sequence, if unable to lock in the first call to `getChildren`, rather than a watcher for all locks on `getChildren`. This prevents a herd effect, by making each lock watch the existence of the lock immediately preceeding it and retry locking when it no longer exists, rather than all locks watching for any lock key to change and re-watching when they do not lock. Sad i didn't catch this myself earlier :(